### PR TITLE
Additional color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Suckless dynamic menu. Since this is a tool I pretty much rely on now, I made a 
 
 Features:
 
+* Additional color scheme in config.h, for entries adjacent to the selection
 * [Mouse support](http://tools.suckless.org/dmenu/patches/mouse-support/)
 * [Scroll](http://tools.suckless.org/dmenu/patches/scroll/) on long lines
 * [Command history](http://tools.suckless.org/dmenu/scripts/dmenu_run_with_command_history/)

--- a/config.def.h
+++ b/config.def.h
@@ -12,7 +12,7 @@ static const char *colors[SchemeLast][2] = {
 	[SchemeNorm] = { "#bbbbbb", "#222222" },
 	[SchemeSel] = { "#eeeeee", "#005577" },
 	[SchemeOut] = { "#000000", "#00ffff" },
-	[SchemeMid] = { "#eeeeee", "#771010" },
+	[SchemeMid] = { "#eeeeee", "#770000" },
 };
 /* -l option; if nonzero, dmenu uses vertical list with given number of lines */
 static unsigned int lines      = 0;

--- a/config.def.h
+++ b/config.def.h
@@ -12,6 +12,7 @@ static const char *colors[SchemeLast][2] = {
 	[SchemeNorm] = { "#bbbbbb", "#222222" },
 	[SchemeSel] = { "#eeeeee", "#005577" },
 	[SchemeOut] = { "#000000", "#00ffff" },
+	[SchemeMid] = { "#eeeeee", "#771010" },
 };
 /* -l option; if nonzero, dmenu uses vertical list with given number of lines */
 static unsigned int lines      = 0;

--- a/config.h
+++ b/config.h
@@ -12,6 +12,7 @@ static const char *colors[SchemeLast][2] = {
 	[SchemeNorm] = { "#c0b18b", "#141214" },
 	[SchemeSel] = { "#000000", "#dd3939" },
 	[SchemeOut] = { "#c0b18b", "#141214" },
+	[SchemeMid] = { "#d0c19b", "#6d0808" },
 };
 /* -l option; if nonzero, dmenu uses vertical list with given number of lines */
 static unsigned int lines      = 0;

--- a/dmenu.c
+++ b/dmenu.c
@@ -127,9 +127,6 @@ drawitem(struct item *item, int x, int y, int w)
 {
 	if (item == sel)
 		drw_setscheme(drw, scheme[SchemeSel]);
-	/*
-	 * new
-	*/
 	else if (item->left == sel || item->right == sel)
 		drw_setscheme(drw, scheme[SchemeMid]);
 	else if (item->out)

--- a/dmenu.c
+++ b/dmenu.c
@@ -26,7 +26,7 @@
 #define TEXTW(X)              (drw_fontset_getwidth(drw, (X)) + lrpad)
 
 /* enums */
-enum { SchemeNorm, SchemeSel, SchemeOut, SchemeLast }; /* color schemes */
+enum { SchemeNorm, SchemeSel, SchemeOut, SchemeMid, SchemeLast }; /* color schemes */
 
 struct item {
 	char *text;
@@ -127,6 +127,11 @@ drawitem(struct item *item, int x, int y, int w)
 {
 	if (item == sel)
 		drw_setscheme(drw, scheme[SchemeSel]);
+	/*
+	 * new
+	*/
+	else if (item->left == sel || item->right == sel)
+		drw_setscheme(drw, scheme[SchemeMid]);
 	else if (item->out)
 		drw_setscheme(drw, scheme[SchemeOut]);
 	else


### PR DESCRIPTION
This patch is my own idea, it allows for an additional color scheme to be defined in `config.h`. Then, the function `drawitem()` determines if the selected item has an item to the left or the right of it. If it does, it sets the color scheme for the adjacent entries to the new one.

    static const char *colors[SchemeLast][2] = {
        [SchemeNorm] = { "#bbbbbb", "#222222" },
        [SchemeSel] = { "#eeeeee", "#005577" },
        [SchemeOut] = { "#000000", "#00ffff" },
        [SchemeMid] = { "#eeeeee", "#770000" }, // new one
    };

This is what a typical `config.h` would look like.